### PR TITLE
Wrong usage of Thelia\Core\Template\Smarty\SmartyParser

### DIFF
--- a/Atos.php
+++ b/Atos.php
@@ -60,7 +60,6 @@ class Atos extends AbstractPaymentModule
         $email_templates_dir = __DIR__.DS.'I18n'.DS.'email-templates'.DS;
 
         if (null === MessageQuery::create()->findOneByName(self::CONFIRMATION_MESSAGE_NAME)) {
-
             $message = new Message();
 
             $message
@@ -105,7 +104,7 @@ class Atos extends AbstractPaymentModule
      */
     private function addParam($key, $value)
     {
-        $this->parameters = sprintf("%s %s=%s",$this->parameters, $key, $value);
+        $this->parameters = sprintf("%s %s=%s", $this->parameters, $key, $value);
 
         return $this;
     }
@@ -159,7 +158,8 @@ class Atos extends AbstractPaymentModule
 
         if (null == $atosCurrency) {
             throw new \InvalidArgumentException(
-                sprintf("Atos does not supprot this currency : %s",
+                sprintf(
+                    "Atos does not supprot this currency : %s",
                     $order->getCurrency()->getCode()
                 )
             );
@@ -198,9 +198,7 @@ class Atos extends AbstractPaymentModule
             } elseif ($datas[1] != 0) {
                 throw new \RuntimeException($datas[2]);
             } else {
-
                 $parser = $this->getContainer()->get('thelia.parser');
-
                 $content = $parser->renderString(
                     file_get_contents(__DIR__ . DS . 'templates' . DS . 'atos' . DS . 'payment.html'),
                     [
@@ -208,17 +206,18 @@ class Atos extends AbstractPaymentModule
                         'form' => $datas[3]
                     ]
                 );
-
                 return Response::create($content);
             }
-        }
-        else {
+        } else {
             throw new \RuntimeException(
                 Translator::getInstance()->trans(
                     'Empty response recevied from Atos binary "%path". Please check path and permissions.',
                     ['%path' => $pathBin],
                     self::MODULE_DOMAIN
-                ));
+                )
+            );
+
+            // FIXME : show something to the customer
         }
     }
 

--- a/Atos.php
+++ b/Atos.php
@@ -13,16 +13,16 @@
 namespace Atos;
 
 use Atos\Model\AtosCurrencyQuery;
+use Propel\Runtime\Connection\ConnectionInterface;
 use Thelia\Core\HttpFoundation\Response;
 use Thelia\Core\Translation\Translator;
 use Thelia\Install\Database;
 use Thelia\Model\Config;
 use Thelia\Model\ConfigQuery;
-use Thelia\Model\MessageQuery;
 use Thelia\Model\Message;
+use Thelia\Model\MessageQuery;
 use Thelia\Model\Order;
 use Thelia\Module\AbstractPaymentModule;
-use Propel\Runtime\Connection\ConnectionInterface;
 use Thelia\Tools\URL;
 
 class Atos extends AbstractPaymentModule
@@ -150,8 +150,7 @@ class Atos extends AbstractPaymentModule
      *  browser.
      *
      *  In many cases, it's necessary to send a form to the payment gateway.
-     *  On your response you can return this form already
-     *  completed, ready to be sent
+     *  On your response you can return this form already completed, ready to be sent
      *
      * @param  \Thelia\Model\Order                       $order processed order
      * @return null|\Thelia\Core\HttpFoundation\Response
@@ -206,6 +205,7 @@ class Atos extends AbstractPaymentModule
                 throw new \RuntimeException($datas[2]);
             } else {
                 $parser = $this->getContainer()->get('thelia.parser');
+
                 $content = $parser->renderString(
                     file_get_contents(__DIR__ . DS . 'templates' . DS . 'atos' . DS . 'payment.html'),
                     [
@@ -213,6 +213,7 @@ class Atos extends AbstractPaymentModule
                         'form' => $datas[3]
                     ]
                 );
+
                 return Response::create($content);
             }
         } else {
@@ -223,7 +224,6 @@ class Atos extends AbstractPaymentModule
                     self::MODULE_DOMAIN
                 )
             );
-
             // FIXME : show something to the customer
         }
     }

--- a/Atos.php
+++ b/Atos.php
@@ -87,7 +87,13 @@ class Atos extends AbstractPaymentModule
     protected function replacePath()
     {
         if (false === is_writable(__DIR__ . '/Config/pathfile')) {
-            throw new \RuntimeException(Translator::getInstance()->trans('Config/pathfile must be writable before installing Atos module', [], self::MODULE_DOMAIN));
+            throw new \RuntimeException(
+                Translator::getInstance()->trans(
+                    'Config/pathfile must be writable before installing Atos module',
+                    [],
+                    self::MODULE_DOMAIN
+                )
+            );
         }
 
         $pathfileContent = file_get_contents(__DIR__ . '/Config/pathfile');
@@ -143,7 +149,8 @@ class Atos extends AbstractPaymentModule
      *  If this method return a \Thelia\Core\HttpFoundation\Response instance, this response is send to the
      *  browser.
      *
-     *  In many cases, it's necessary to send a form to the payment gateway. On your response you can return this form already
+     *  In many cases, it's necessary to send a form to the payment gateway.
+     *  On your response you can return this form already
      *  completed, ready to be sent
      *
      * @param  \Thelia\Model\Order                       $order processed order

--- a/Controller/PaymentController.php
+++ b/Controller/PaymentController.php
@@ -11,6 +11,7 @@
 /*************************************************************************************/
 
 namespace Atos\Controller;
+
 use Atos\Atos;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Thelia\Core\HttpFoundation\Response;
@@ -54,7 +55,7 @@ class PaymentController extends BasePaymentModuleController
 
             if ($result['code'] == '' && $result['error'] == '') {
                 $this->getLog()
-                    ->addError(sprintf('Response request not found in %s'. $binResponse));
+                    ->addError(sprintf('Response request not found in %s' . $binResponse));
 
             } elseif ($result['error'] != 0) {
                 $this->getLog()
@@ -63,8 +64,7 @@ class PaymentController extends BasePaymentModuleController
 
             $this->getLog()
                 ->addInfo(sprintf('response parameters : %s', print_r($result, true)));
-        }
-        else {
+        } else {
             $this->getLog()
                 ->addError(sprintf('Got empty response from binary %s, check path and permissions'. $binResponse));
         }
@@ -72,7 +72,8 @@ class PaymentController extends BasePaymentModuleController
         return Response::create();
     }
 
-    protected function parseResult($result) {
+    protected function parseResult($result)
+    {
         return [
             'code' => $result[1],
             'error' => $result[2],

--- a/EventListeners/SendConfirmationEmail.php
+++ b/EventListeners/SendConfirmationEmail.php
@@ -16,11 +16,9 @@ use Atos\Atos;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Thelia\Core\Event\Order\OrderEvent;
 use Thelia\Core\Event\TheliaEvents;
-use Thelia\Core\Template\Smarty\SmartyParser;
+use Thelia\Core\Template\ParserInterface;
 use Thelia\Log\Tlog;
 use Thelia\Mailer\MailerFactory;
-use Thelia\Model\ConfigQuery;
-use Thelia\Model\MessageQuery;
 
 /**
  * Class SendEmailConfirmation
@@ -30,7 +28,7 @@ use Thelia\Model\MessageQuery;
 class SendConfirmationEmail implements EventSubscriberInterface
 {
     /**
-     * @var SmartyParser
+     * @var ParserInterface
      */
     protected $parser;
 
@@ -39,7 +37,7 @@ class SendConfirmationEmail implements EventSubscriberInterface
      */
     protected $mailer;
 
-    public function __construct(SmartyParser $parser, MailerFactory $mailer)
+    public function __construct(ParserInterface $parser, MailerFactory $mailer)
     {
         $this->parser = $parser;
         $this->mailer = $mailer;
@@ -50,39 +48,16 @@ class SendConfirmationEmail implements EventSubscriberInterface
         $atos = new Atos();
         $order = $event->getOrder();
         if ($order->isPaid() && $atos->isPaymentModuleFor($order)) {
-            $contact_email = ConfigQuery::read('store_email', false);
+            $this->mailer->sendEmailToCustomer(
+                Atos::CONFIRMATION_MESSAGE_NAME,
+                $order->getCustomer(),
+                [
+                    'order_id' => $order->getId(),
+                    'order_ref' => $order->getRef()
+                ]
+            );
 
-            Tlog::getInstance()->debug("Sending confirmation email from store contact e-mail $contact_email");
-
-            if ($contact_email) {
-                $message = MessageQuery::create()
-                    ->filterByName(Atos::CONFIRMATION_MESSAGE_NAME)
-                    ->findOne();
-
-                if (false === $message) {
-                    throw new \Exception(sprintf("Failed to load message '%s'.", Atos::CONFIRMATION_MESSAGE_NAME));
-                }
-
-                $order = $event->getOrder();
-                $customer = $order->getCustomer();
-
-                $this->parser->assign('order_id', $order->getId());
-                $this->parser->assign('order_ref', $order->getRef());
-
-                $message
-                    ->setLocale($order->getLang()->getLocale());
-
-                $instance = \Swift_Message::newInstance()
-                    ->addTo($customer->getEmail(), $customer->getFirstname() . " " . $customer->getLastname())
-                    ->addFrom($contact_email, ConfigQuery::read('store_name'));
-
-                // Build subject and body
-                $message->buildMessage($this->parser, $instance);
-
-                $this->mailer->send($instance);
-
-                Tlog::getInstance()->debug("Confirmation email sent to customer " . $customer->getEmail());
-            }
+            Tlog::getInstance()->debug("Confirmation email sent to customer " . $order->getCustomer()->getEmail());
         }
     }
 


### PR DESCRIPTION
This PR fixes the use of Thelia\Core\Template\Smarty\SmartyParser instead of Thelia\Core\Template\ParserInterface.

The PR contains also minor CS fixes, and adds some log messages.