### PR TITLE
PaymentController uses the "return_context" field instead of "transaction_id"

### DIFF
--- a/Atos.php
+++ b/Atos.php
@@ -32,14 +32,14 @@ use Thelia\Tools\URL;
 class Atos extends AbstractPaymentModule
 {
     const MODULE_DOMAIN = 'atos';
-    
+
     /**
      * The confirmation message identifier
      */
     const CONFIRMATION_MESSAGE_NAME = 'atos_payment_confirmation';
-    
+
     private $parameters;
-    
+
     public function postActivation(ConnectionInterface $con = null)
     {
         // Setup some default values
@@ -49,30 +49,28 @@ class Atos extends AbstractPaymentModule
             Atos::setConfigValue('maximum_amount', 0);
             Atos::setConfigValue('send_payment_confirmation_message', 1);
         }
-        
+
         // Try to chmod binaries if they're not executables
         $binFile = Atos::getBinDirectory() . 'request';
         if (! is_executable($binFile)) {
             @chmod($binFile, 0755);
         }
-        
+
         $binFile = Atos::getBinDirectory() . 'response';
         if (! is_executable($binFile)) {
             @chmod($binFile, 0755);
         }
-        
+
         $database = new Database($con);
-        
+
         $database->insertSql(null, array(
             __DIR__ . DS . 'Config'.DS.'thelia.sql'
         ));
-        
+
         // Create payment confirmation message from templates, if not already defined
-        $email_templates_dir = __DIR__.DS.'I18n'.DS.'email-templates'.DS;
-        
         if (null === MessageQuery::create()->findOneByName(Atos::CONFIRMATION_MESSAGE_NAME)) {
             $message = new Message();
-            
+
             $message
                 ->setName(Atos::CONFIRMATION_MESSAGE_NAME)
                 ->setHtmlTemplateFileName('atos-payment-confirmation.html')
@@ -86,10 +84,10 @@ class Atos extends AbstractPaymentModule
                 ->save()
             ;
         }
-        
+
         $this->replacePath();
     }
-    
+
     public function update($currentVersion, $newVersion, ConnectionInterface $con = null)
     {
         // Migrate old configuration
@@ -98,35 +96,35 @@ class Atos extends AbstractPaymentModule
                 /** @var Config $atosConfig */
                 foreach ($atosConfigs as $atosConfig) {
                     Atos::setConfigValue($atosConfig->getName(), $atosConfig->getValue());
-                    
+
                     $atosConfig->delete($con);
                 }
             }
         }
-        
+
         parent::update($currentVersion, $newVersion, $con);
     }
-    
+
     public function destroy(ConnectionInterface $con = null, $deleteModuleData = false)
     {
         if ($deleteModuleData) {
             $database = new Database($con);
-            
+
             $database->execute('drop table `atos_currency`');
-            
+
             MessageQuery::create()->findOneByName(Atos::CONFIRMATION_MESSAGE_NAME)->delete();
         }
     }
-    
+
     protected function replacePath()
     {
         $pathfile = $this->getPathfilePath();
-        
+
         $pathfileContent = @file_get_contents($pathfile . '.dist');
-        
+
         if ($pathfileContent) {
             $pathfileContent = str_replace('__PATH__', __DIR__, $pathfileContent);
-            
+
             if (! file_put_contents($this->getConfigDirectory() . 'pathfile', $pathfileContent)) {
                 throw new \RuntimeException(
                     Translator::getInstance()->trans(
@@ -146,7 +144,7 @@ class Atos extends AbstractPaymentModule
             );
         }
     }
-    
+
     /**
      * @param  string $key   atos key parameter
      * @param  string $value parameter value
@@ -155,15 +153,15 @@ class Atos extends AbstractPaymentModule
     protected function addParam($key, $value)
     {
         $this->parameters = sprintf("%s %s=%s", $this->parameters, $key, $value);
-        
+
         return $this;
     }
-    
+
     protected function getParameters()
     {
         return trim($this->parameters);
     }
-    
+
     /**
      *
      * generate a transaction id for atos solution
@@ -173,18 +171,18 @@ class Atos extends AbstractPaymentModule
     private function generateTransactionID()
     {
         $transId = Atos::getConfigValue('atos_transactionId', 1);
-        
+
         $transId = 1 + intval($transId);
-        
+
         if (strlen($transId) > 6) {
             $transId = 1;
         }
-        
+
         Atos::setConfigValue('atos_transactionId', $transId);
-        
+
         return sprintf("%06d", $transId);
     }
-    
+
     /**
      *
      *  Method used by payment gateway.
@@ -201,11 +199,11 @@ class Atos extends AbstractPaymentModule
     public function pay(Order $order)
     {
         $pathBin = Atos::getBinDirectory() .'request';
-        
+
         $atosCurrency = AtosCurrencyQuery::create()->findPk(
             $order->getCurrency()->getCode()
         );
-        
+
         if (null == $atosCurrency) {
             throw new \InvalidArgumentException(
                 sprintf(
@@ -214,17 +212,17 @@ class Atos extends AbstractPaymentModule
                 )
             );
         }
-        
+
         $amount = $order->getTotalAmount();
         $amount = number_format($amount, $atosCurrency->getDecimals(), '', '');
-        
+
         $transactionId = $this->generateTransactionID();
-        
+
         $order->setTransactionRef($transactionId)->save();
-        
+
         /** @var Router $router */
         $router = $this->getContainer()->get('router.atos');
-        
+
         $this
             ->addParam('pathfile', Atos::getPathfilePath())
             ->addParam('merchant_id', Atos::getConfigValue('atos_merchantId'))
@@ -237,13 +235,15 @@ class Atos extends AbstractPaymentModule
             ->addParam('automatic_response_url', URL::getInstance()->absoluteUrl($router->generate('atos.payment.confirmation')))
             ->addParam('cancel_return_url', URL::getInstance()->absoluteUrl($router->generate('atos.payment.cancel', [ 'orderId' => $order->getId() ])))
             ->addParam('normal_return_url', $this->getPaymentSuccessPageUrl($order->getId()))
+            // base64 encode the ref to prevent problems with unallowed characters
+            ->addParam('return_context', base64_encode($order->getRef()))
         ;
-        
+
         $encrypt = exec(sprintf("%s %s", $pathBin, $this->getParameters()));
-        
+
         if (! empty($encrypt)) {
             $datas = explode('!', $encrypt);
-            
+
             if ($datas[1] == '' && $datas[2] == '') {
                 throw new \RuntimeException(
                     Translator::getInstance()->trans('Request binary not found in "%path"', ['%path' => $pathBin])
@@ -253,19 +253,18 @@ class Atos extends AbstractPaymentModule
             } else {
                 /** @var ParserInterface $parser */
                 $parser = $this->getContainer()->get('thelia.parser');
-                
+
                 $parser->setTemplateDefinition(
-                    $parser->getTemplateHelper()->getActiveFrontTemplate(),
-                    true
+                    $parser->getTemplateHelper()->getActiveFrontTemplate()
                 );
-                
+
                 $content = $parser->render('atos/payment.html', [
                     'site_name' => self::getConfigValue('store_name'),
                     'form' => $datas[3],
                     'order_id' => $order->getId()
                 ]);
-                
-                return Response::create($content);
+
+                return new Response($content);
             }
         } else {
             throw new \RuntimeException(
@@ -278,39 +277,39 @@ class Atos extends AbstractPaymentModule
             // FIXME : show something to the customer
         }
     }
-    
+
     /**
      * @return boolean true to allow usage of this payment module, false otherwise.
      */
     public function isValidPayment()
     {
         $valid = false;
-        
+
         // Check config files
         $parmcomFile = Atos::getConfigDirectory() . 'parmcom.' . Atos::getConfigValue('atos_merchantId', '0');
         $certifFile = Atos::getConfigDirectory() . 'certif.fr.' . Atos::getConfigValue('atos_merchantId', '0');
-        
+
         if (is_readable($parmcomFile) && is_readable($certifFile)) {
             $mode = Atos::getConfigValue('atos_mode', false);
-            
+
             // If we're in test mode, do not display Payzen on the front office, except for allowed IP addresses.
             if ('TEST' == $mode) {
                 $raw_ips = explode("\n", Atos::getConfigValue('atos_allowed_ip_list', ''));
-                
+
                 $allowed_client_ips = array();
-                
+
                 foreach ($raw_ips as $ip) {
                     $allowed_client_ips[] = trim($ip);
                 }
-                
+
                 $client_ip = $this->getRequest()->getClientIp();
-                
+
                 $valid = in_array($client_ip, $allowed_client_ips);
-                
+
             } elseif ('PRODUCTION' == $mode) {
                 $valid = true;
             }
-            
+
             if ($valid) {
                 // Check if total order amount is in the module's limits
                 $valid = $this->checkMinMaxAmount();
@@ -326,7 +325,7 @@ class Atos extends AbstractPaymentModule
         }
         return $valid;
     }
-    
+
     /**
      * Check if total order amount is in the module's limits
      *
@@ -336,26 +335,26 @@ class Atos extends AbstractPaymentModule
     {
         // Check if total order amount is in the module's limits
         $order_total = $this->getCurrentOrderTotalAmount();
-        
+
         $min_amount = Atos::getConfigValue('atos_minimum_amount', 0);
         $max_amount = Atos::getConfigValue('atos_maximum_amount', 0);
-        
+
         return
             $order_total > 0
             &&
             ($min_amount <= 0 || $order_total >= $min_amount) && ($max_amount <= 0 || $order_total <= $max_amount);
     }
-    
+
     public static function getBinDirectory()
     {
         return __DIR__ . DS . 'bin' . DS;
     }
-    
+
     public static function getConfigDirectory()
     {
         return __DIR__ . DS . 'Config' . DS;
     }
-    
+
     public static function getPathfilePath()
     {
         return Atos::getConfigDirectory() . 'pathfile';

--- a/Atos.php
+++ b/Atos.php
@@ -359,4 +359,15 @@ class Atos extends AbstractPaymentModule
     {
         return Atos::getConfigDirectory() . 'pathfile';
     }
+
+    /**
+     * if you want, you can manage stock in your module instead of order process.
+     * Return false to decrease the stock when order status switch to pay
+     *
+     * @return bool
+     */
+    public function manageStockOnCreation()
+    {
+        return false;
+    }
 }

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -7,7 +7,7 @@
     <descriptive locale="fr_FR">
         <title>Module de paiement Atos-SIPS</title>
     </descriptive>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <author>
         <name>Manuel Raynaud, Franck Allimant</name>
         <email>manu@thelia.net, franck@cqfdev.fr</email>

--- a/Config/module.xml
+++ b/Config/module.xml
@@ -7,7 +7,7 @@
     <descriptive locale="fr_FR">
         <title>Module de paiement Atos-SIPS</title>
     </descriptive>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <author>
         <name>Manuel Raynaud, Franck Allimant</name>
         <email>manu@thelia.net, franck@cqfdev.fr</email>

--- a/Controller/PaymentController.php
+++ b/Controller/PaymentController.php
@@ -79,12 +79,8 @@ class PaymentController extends BasePaymentModuleController
                         )
                     );
                 } elseif ($result['response_code'] == '00') {
-                    $atos = new Atos();
-
-                    $order = OrderQuery::create()
-                        ->filterByTransactionRef($result['transaction_id'])
-                        ->filterByPaymentModuleId($atos->getModuleModel()->getId())
-                        ->findOne();
+                    $orderRef = base64_decode($result['return_context']);
+                    $order = OrderQuery::create()->findOneByRef($orderRef);
 
                     if ($order) {
                         $this->confirmPayment($order->getId());
@@ -99,8 +95,8 @@ class PaymentController extends BasePaymentModuleController
                     } else {
                         $this->getLog()->addError(
                             $this->getTranslator()->trans(
-                                'Cannot find an order for transaction ID "%trans"',
-                                ['%trans' => $result['transaction_id']],
+                                'Cannot find an order having reference "%rc"',
+                                ['%rc' => $orderRef],
                                 Atos::MODULE_DOMAIN
                             )
                         );

--- a/I18n/en_US.php
+++ b/I18n/en_US.php
@@ -8,7 +8,7 @@ return array(
     'Atos payment module is nort properly configured. Please check module configuration in your back-office.' => 'Atos payment module is nort properly configured. Please check module configuration in your back-office.',
     'Atos platform request processing terminated.' => 'Atos platform request processing terminated.',
     'Atos-SIPS platform request received.' => 'Atos-SIPS platform request received.',
-    'Cannot find an order for transaction ID "%trans"' => 'Cannot find an order for transaction ID "%trans"',
+    'Cannot find an order having reference "%rc"' => 'Cannot find an order having reference "%rc"',
     'Cannot validate order. Response code is %resp' => 'Cannot validate order. Response code is %resp',
     'Empty response recevied from Atos binary "%path". Please check path and permissions.' => 'Empty response recevied from Atos binary "%path". Please check path and permissions.',
     'Error %code while processing response, with message %message' => 'Error %code while processing response, with message %message',

--- a/I18n/fr_FR.php
+++ b/I18n/fr_FR.php
@@ -8,7 +8,7 @@ return array(
     'Atos payment module is nort properly configured. Please check module configuration in your back-office.' => 'Le module de paiement Atos n\'est pas correctement configuré. Merci de vérifier la configuration dans votre back-office.',
     'Atos platform request processing terminated.' => 'Traitemenr de la requête ATOS terminé.',
     'Atos-SIPS platform request received.' => 'Réception d\'une requête ATOS',
-    'Cannot find an order for transaction ID "%trans"' => 'Aucune commande ne correspond à l\'ID de transaction "%trans"',
+    'Cannot find an order having reference "%rc"' => 'Aucune commande ne correspond au return_context "%rc"',
     'Cannot validate order. Response code is %resp' => 'La commande ne peut être validée. Le code de réponse est %resp',
     'Empty response recevied from Atos binary "%path". Please check path and permissions.' => 'Le binaire Atos %path a retourné une réponse vide. Vérifiez que ce fichier est exécutable.',
     'Error %code while processing response, with message %message' => 'Erreur %code lors du traitement de la réponse, avec le message %message',


### PR DESCRIPTION
Instead of using the "transaction_id" field for retrieving the Order, the PaymentController now uses the "return_context" field, which is initialized in the payment request with the order reference.

This is a safe way to remove filtering by module ID when searching the paid order :
```
$order = OrderQuery::create()
    ->filterByTransactionRef($result['transaction_id'])
    ->filterByPaymentModuleId($atos->getModuleModel()->getId())
     ->findOne();
```
We have now :

`$order = OrderQuery::create()->findOneByRef($result['return_context']);`

This way, modules extending Atos (such as AtosNx) are naturally supported the Atos PaymentController.

The PR also include minor code style fixes